### PR TITLE
Reflect package renaming on Fedora

### DIFF
--- a/Dockerfile.fedora27
+++ b/Dockerfile.fedora27
@@ -8,7 +8,7 @@ RUN true \
     pulseaudio \
     gtk3 \
     pygobject3 \
-    python-gobject \
+    python2-gobject \
     dbus-python \
     pycairo \
     python2-mutagen \


### PR DESCRIPTION
all python-* packages get renamed to python2-*.

See also:
https://fedoraproject.org/wiki/FinalizingFedoraSwitchtoPython3
https://src.fedoraproject.org/rpms/pygobject3/commits/f27