### PR TITLE
Fedora: Prepare for Fedora 28

### DIFF
--- a/Dockerfile.fedora28
+++ b/Dockerfile.fedora28
@@ -1,5 +1,5 @@
 
-FROM docker.io/fedora:26
+FROM docker.io/fedora:28
 MAINTAINER Dustin Spicuzza <dustin@virtualroadside.com>
 
 RUN true \
@@ -8,7 +8,7 @@ RUN true \
     pulseaudio \
     gtk3 \
     pygobject3 \
-    python-gobject \
+    python2-gobject \
     dbus-python \
     pycairo \
     python2-mutagen \

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 cd `dirname $0`
 
-TOBUILD=${1:-debian8 debian9 fedora26 fedora27 ubuntu16.04 ubuntu17.10}
+TOBUILD=${1:-debian8 debian9 fedora27 fedora28 ubuntu16.04 ubuntu17.10}
 BASE=docker.io/exaile/gst-python
 
 for i in ${TOBUILD}; do


### PR DESCRIPTION
Fedora 28 will be released soon and has already passed its beta release. See https://fedoraproject.org/wiki/Releases/28/Schedule for details.